### PR TITLE
Drop python version to 3.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -60,4 +60,4 @@ bdd-tester = "*"
 markdown = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"


### PR DESCRIPTION
This makes it easier to deploy with uswgi on Ubuntu 18.04 LTS, and
appears not to break anything.