### PR TITLE
add condition to check for Nonetype in template

### DIFF
--- a/iatidataquality/templates/surveys/ind_commitment_final.html
+++ b/iatidataquality/templates/surveys/ind_commitment_final.html
@@ -38,7 +38,7 @@
         <tr>
             <td><span>Donor review</span></td>
 
-            {% if organisation.organisation_responded >= 3 %}
+            {% if organisation.organisation_responded and organisation.organisation_responded >= 3 %}
                 <td colspan="3">No response</td>
             {% else %}
                 <td>{{surveydata.donorreview[indicator.indicator.id].OrganisationSurveyData.ordinal_value}}<br />
@@ -125,7 +125,7 @@
 
             <tr>
                 <td><span>{{data[indicator.indicator.id].Workflow.title}}</span></td>
-                {% if organisation.organisation_responded >= 3 %}
+                {% if organisation.organisation_responded and organisation.organisation_responded >= 3 %}
                     <td colspan="3">No response</td>
                 {% else %}
                     <td>

--- a/iatidataquality/templates/surveys/ind_zero_final.html
+++ b/iatidataquality/templates/surveys/ind_zero_final.html
@@ -59,8 +59,8 @@
         {% set data = surveydata['donorreview'] %}
         <tr>
             <td><span>Donor review</span></td>
-            {% if organisation.organisation_responded >= 3 %}
-                <td colspan="3">No response</td>
+            {% if organisation.organisation_responded and organisation.organisation_responded >= 3 %}
+              <td colspan="3">No response</td>
             {% else %}
                 <td>
                   {% if indicator.indicator.indicator_ordinal %}
@@ -160,8 +160,8 @@
         <tr>
             <td><span>{{data[indicator.indicator.id].Workflow.title}}</span></td>
 
-            {% if organisation.organisation_responded >= 3 %}
-                <td colspan="3">No response</td>
+            {% if organisation.organisation_responded and organisation.organisation_responded >= 3 %}
+              <td colspan="3">No response</td>
             {% else %}
                 <td>
                 <span class="label label-{{accepted_class}}" title="Agree or disagree">{{accepted}}</span>


### PR DESCRIPTION
In python 3 None is not comparable to integers so operators between these types return an error. This checks for Nonetypes before the comparison.