### PR TITLE
Correct text to "Aid Transparency Index"

### DIFF
--- a/iatidataquality/templates/organisation_index_publication.html
+++ b/iatidataquality/templates/organisation_index_publication.html
@@ -21,14 +21,14 @@
 		{{organisation.organisation_name}}</a>
 	</h1>
 
-    <h3>{{ ati_year }} Global Aid Review data </h3>
+    <h3>{{ ati_year }} Aid Transparency Index data </h3>
     <div class="">
         <div class="row">
             <div class="col-md-12">
                 <h2>Tracking aid transparency improvements over time.</h2>
                 <p class="lead">This page shows the information
                 collected for {{organisation.organisation_name}} for
-                the {{ ati_year }} Global Aid Review and tracks changes to
+                the {{ ati_year }} Aid Transparency Index and tracks changes to
                 the information found over the course of the
              	data collection period.</p>
             </div>

--- a/iatidataquality/templates/organisations.html
+++ b/iatidataquality/templates/organisations.html
@@ -26,7 +26,7 @@
     <p class="lead">
 
 	  The following organisations are included in
-	  the {{ ati_year }} Global Aid Review. Each organisation's page contains an
+	  the {{ ati_year }} Aid Transparency Index. Each organisation's page contains an
 	  initial assessment of the quality of the aid information they
 	  publish. Publish What You Fund will work with these
 	  organisations and independent reviewers over the course of the

--- a/iatidataquality/templates/surveys/_survey_collect.html
+++ b/iatidataquality/templates/surveys/_survey_collect.html
@@ -15,7 +15,7 @@
 
 {% block guidance %}
         <p class="lead">Thank you for agreeing to contribute to the {{ ati_year }}
-          2020 Aid Transparency Index. The data you are collecting will help to
+          Aid Transparency Index. The data you are collecting will help to
           accurately capture the levels of aid information available.</p>
         <h4>Guidelines</h4>
         <ol>


### PR DESCRIPTION
In places the website text used "Global Aid Review" This PR corrects that to "Aid Transparency Index". It also edits out the year '2020' in the _survey_collect.html file which should be drawn from the ATI_YEAR variable