### PR TITLE
Update Korea for self-ref and prefix

### DIFF
--- a/beta/infotest.py
+++ b/beta/infotest.py
@@ -265,7 +265,14 @@ def test_participating_org_refs(publisher_prefix, activity_tree, self_refs):
     # publisher matching
     publisher_idents = set(publishers_by_ident)
 
+    # temporary fix for Korean organisations
+    if publisher_prefix == "odakorea":
+        korean_orgs = set([x for x in participating_orgs_no_self_ref if x.startswith('KR-GOV')])
+        publisher_idents = publisher_idents | korean_orgs
+
     publisher_matches = participating_orgs_no_self_ref & publisher_idents
+
+    # print(publisher_matches)
 
     # print('matching publisher:', publisher_matches)
 
@@ -302,6 +309,9 @@ def test_participating_org_refs(publisher_prefix, activity_tree, self_refs):
 
     score = (len(participating_orgs_no_self_ref) * 1.0 - len(failed_to_match))/denominator
     explanation = f'score: ({len(participating_orgs_no_self_ref)} - {len(failed_to_match)})/{denominator}'
+
+    # print(score)
+    # print(explanation)
 
     return explanation, score
 

--- a/iatidataquality/cli.py
+++ b/iatidataquality/cli.py
@@ -94,6 +94,7 @@ def import_users(filename):
 @click.option("--org-ids")
 @click.option("--test-ids")
 def setup_sampling(date, filename, org_ids, test_ids):
+    """Generate the sampling database (Environment variable PWYF_SAMPLE_SIZE can be used to set the number of samples per test)"""
     iati_result_path = app.config.get('IATI_RESULT_PATH')
     try:
         snapshot_dates = listdir(join(iati_result_path))

--- a/tests/organisations_with_identifiers.csv
+++ b/tests/organisations_with_identifiers.csv
@@ -26,7 +26,7 @@ U.S.A,IADB,IADB,XI-IATI-IADB,XI-IATI-IADB,,iadb,
 Ireland,Irish Aid,"Ireland, Irish Aid",XM-DAC-21-1,XM-DAC-21-1,XM-DAC-21-1,irishaid,
 Italy,AICS,"Italy, AICS",XM-DAC-6-4,XM-DAC-6-4,XM-DAC-6-4,aics,
 Japan,JICA,"Japan, JICA",XM-DAC-701-8,XM-DAC-701-8,XM-DAC-701-8,jica,
-South Korea,KOICA,"Korea, KOICA",KR-4,KR-4,KR-4,odakorea,participating-org[@role='3'][@ref='KR-GOV-051']|organisation-identifier/text()='KR-GOV-051'
+South Korea,KOICA,"Korea, KOICA",KR-4,KR-4,KR-GOV-051,odakorea,participating-org[@role='3'][@ref='KR-GOV-051']|organisation-identifier/text()='KR-GOV-051'
 Netherlands,MFA,"Netherlands, MFA",XM-DAC-7,XM-DAC-7,XM-DAC-7,minbuza_nl,
 New Zealand,MFAT,"New Zealand, MFAT",NZ-1,NZ-1,NZ-1,mfat,
 Norway,MFA,"Norway, MFA",NO-4,NO-4,NO-4,norad,


### PR DESCRIPTION
We are only interested in KOICA, so we have adjusted the self-ref to KOICA's self-ref. We also want to pass all organisations in the participating org test that have the KR-GOV prefix