### PR TITLE
README updates and small dockerfile fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd aid-transparency-tracker
 Setup a virtual environment, and install dependencies:
 
 ``` bash
-python3 -m venv .ve
+python3.8 -m venv .ve
 echo "export FLASK_APP=iatidataquality/__init__.py" >> .ve/bin/activate
 source .ve/bin/activate
 pip install "setuptools<58"
@@ -29,13 +29,13 @@ Install and run a postgres database. If you have docker-compose, you can do this
 docker-compose -f docker-compose-postgres.yml up -d
 ```
 
-Copy and if necessary edit the config.py.tmpl. (If you installed postgres using docker-compose you shkouldn't need to edit anything.)
+Copy and if necessary edit the config.py.tmpl. (If you installed postgres using docker-compose you shouldn't need to edit anything.)
 
 ``` bash
 cp config.py.tmpl config.py
 ```
 
-If you're running this for the first time, edit `tests/organisations_with_identifiers.csv` to have less organisations. eg.. For just one:
+If you're running this for the first time, edit `tests/organisations_with_identifiers.csv` to have less organisations. e.g. For just one:
 
 ```
 cp tests/organisations_with_identifiers_sample_1_org.csv tests/organisations_with_identifiers.csv
@@ -47,7 +47,7 @@ Finally, run the setup script to populate your database:
 flask setup
 ```
 
-This will prompt you to create a new admin user.
+This will prompt you to create a new admin user (this will be the username & password you use to login to the ATT web app, once it is up and running--see 'Running' section below).
 
 ## Fetching and testing data
 
@@ -55,7 +55,8 @@ This will prompt you to create a new admin user.
     ``` bash
     flask download_data
     ```
-   The data will be downloaded to the __iatikitcache__ directory by default, or you can add an iatikit.ini file to specify a different location.
+   The data will be downloaded to the `__iatikitcache__` directory by default, or you can add an `iatikit.ini` file to specify a different location.
+
 
 2. The relevant data (according to the organisations in your database) should then be moved into place using:
     ``` bash
@@ -63,11 +64,13 @@ This will prompt you to create a new admin user.
     ```
    This will move files into the `IATI_DATA_PATH` specified in your config.py
 
+
 3. Tests are run on this data using:
     ``` bash
     flask test_data
     ```
    The complete output of this is stored as CSV files in the `IATI_RESULT_PATH` specified in your config.py
+
 
 4. Finally, you can refresh the aggregate data shown in the tracker using:
     ``` bash

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=dcf5636196aa409b75a0f7a73a314df4c8fc05d9b9fc0cad9b87ee64f2d6d2b1
+      - POSTGRES_DB=iatidq
     ports:
       - '127.0.0.1:5433:5432'
     volumes:


### PR DESCRIPTION
Changed README to specify `python3.8`, since it doesn't work in 3.7 or 3.10.
Fixed a few types in README.

Added database name to docker compose config file.