### PR TITLE
timeliness: if no timeliness score, hide the alert

### DIFF
--- a/iatidataquality/organisations.py
+++ b/iatidataquality/organisations.py
@@ -285,8 +285,11 @@ def organisation_publication(organisation_code, aggregation_type):
     agg_type = [agg_detail(agt) for agt in all_aggregation_types]
 
     timeliness_score = get_timeliness_score(organisation.frequency, organisation.timelag)
-    max_points = round(100.0 * timeliness_score / 1.5 + 100.0/3, 1)
-    timeliness_alert = 'It looks like you publish {} with a time lag of {}, so the maximum you can score for IATI data is {} points. The total points for the relevant indicators have been adjusted accordingly.'.format(organisation.frequency, organisation.timelag, max_points)
+    if timeliness_score is None:
+        timeliness_alert = None
+    else:
+        max_points = round(100.0 * timeliness_score / 1.5 + 100.0/3, 1)
+        timeliness_alert = 'It looks like you publish {} with a time lag of {}, so the maximum you can score for IATI data is {} points. The total points for the relevant indicators have been adjusted accordingly.'.format(organisation.frequency, organisation.timelag, max_points)
 
     def annotate(res, zero):
         def annotate_test(t):


### PR DESCRIPTION
(Previously we were getting a TypeError).

https://trello.com/c/fiUBAsmE/284-china-internal-server-error