### PR TITLE
Organisation conditions feedback

### DIFF
--- a/iatidataquality/organisations_feedback.py
+++ b/iatidataquality/organisations_feedback.py
@@ -7,11 +7,39 @@
 #  This programme is free software; you may redistribute and/or modify
 #  it under the terms of the GNU Affero General Public License v3.0
 
+import re
+
 from flask import render_template, flash, request, redirect, url_for
 from flask_login import current_user
 
 from . import usermanagement
 from iatidq import dqorganisations, models
+
+
+def _applied_conditions(organisation):
+    from iatidataquality import db
+    rows = db.session.query(
+        models.OrganisationCondition, models.Test
+    ).filter(
+        models.OrganisationCondition.organisation_id == organisation.id
+    ).join(
+        models.Test, models.OrganisationCondition.test_id == models.Test.id
+    ).all()
+
+    lines = set()
+    for oc, test in rows:
+        if not test.name:
+            continue
+        m = re.search(r"Then (?:every )?`([^/`@\[\s]+)", test.name)
+        if not m:
+            continue
+        element = m.group(1)
+        org_code = organisation.organisation_code
+        if oc.condition == 'activity level':
+            lines.add(f"{org_code} does not use {element} at activity level")
+        elif oc.condition == 'activity hierarchy':
+            lines.add(f"{org_code} does not use {element} at activity hierarchy {oc.condition_value}")
+    return sorted(lines)
 
 
 def organisation_feedback(organisation_code=None):
@@ -34,10 +62,12 @@ def organisation_feedback(organisation_code=None):
         existing_feedback = models.OrganisationConditionFeedback.query.filter_by(
             organisation_id=organisation.id
         ).all()
+        applied = _applied_conditions(organisation)
         return render_template(
             "organisation_feedback.html",
             organisation=organisation,
             existing_feedback=existing_feedback,
+            applied_conditions=applied,
             admin=usermanagement.check_perms('admin'),
             loggedinuser=current_user)
     else:

--- a/iatidataquality/organisations_feedback.py
+++ b/iatidataquality/organisations_feedback.py
@@ -25,16 +25,37 @@ def organisation_feedback(organisation_code=None):
                         'element': request.form['element'+condition],
                         'where': request.form['where'+condition]
                 }
-                if dqorganisations.addFeedback(data):
+                result = dqorganisations.addFeedback(data)
+                if result:
                     flash('Successfully added condition.', 'success')
                 else:
-                    flash("Couldn't add condition.", 'danger')
+                    flash("This condition has already been added.", 'warning')
 
+        existing_feedback = models.OrganisationConditionFeedback.query.filter_by(
+            organisation_id=organisation.id
+        ).all()
         return render_template(
             "organisation_feedback.html",
             organisation=organisation,
+            existing_feedback=existing_feedback,
             admin=usermanagement.check_perms('admin'),
             loggedinuser=current_user)
     else:
         flash('No organisation supplied', 'danger')
         return redirect(url_for('get_organisations'))
+
+
+def delete_org_feedback(organisation_code, feedback_id):
+    organisation = models.Organisation.where(organisation_code=organisation_code).first()
+    if organisation is None:
+        flash('Organisation not found', 'danger')
+        return redirect(url_for('get_organisations'))
+    feedback = models.OrganisationConditionFeedback.query.filter_by(
+        id=feedback_id, organisation_id=organisation.id
+    ).first()
+    if feedback is None:
+        flash('Condition not found', 'danger')
+    else:
+        dqorganisations.deleteFeedback(feedback_id)
+        flash('Condition deleted.', 'success')
+    return redirect(url_for('organisation_feedback', organisation_code=organisation_code))

--- a/iatidataquality/publisher_conditions.py
+++ b/iatidataquality/publisher_conditions.py
@@ -7,6 +7,7 @@
 #  This programme is free software; you may redistribute and/or modify
 #  it under the terms of the GNU Affero General Public License v3.0
 
+import re
 from io import StringIO, BytesIO
 
 from flask import render_template, flash, request, redirect, url_for, send_file
@@ -198,14 +199,40 @@ def import_organisation_conditions(step=None):
             loggedinuser=current_user)
 
 
+def _element_from_test_name(test_name):
+    if not test_name:
+        return None
+    m = re.search(r"Then (?:every )?`([^/`@\[\s]+)", test_name)
+    return m.group(1) if m else None
+
+
+def _condition_line(org_code, element, condition, condition_value):
+    if condition == 'activity level':
+        return f"{org_code} does not use {element} at activity level"
+    if condition == 'activity hierarchy':
+        return f"{org_code} does not use {element} at activity hierarchy {condition_value}"
+    return None
+
+
 def export_organisation_conditions():
-    conditions = db.session.query(
-        OrganisationCondition.description).distinct().all()
-    conditionstext = ""
-    for i, condition in enumerate(conditions):
-        if (i != 0):
-            conditionstext = conditionstext + "\n"
-        conditionstext = conditionstext + condition.description
+    rows = db.session.query(
+        OrganisationCondition, Organisation, Test
+    ).join(
+        Organisation, OrganisationCondition.organisation_id == Organisation.id
+    ).join(
+        Test, OrganisationCondition.test_id == Test.id
+    ).all()
+
+    lines = set()
+    for oc, org, test in rows:
+        element = _element_from_test_name(test.name)
+        if element is None:
+            continue
+        line = _condition_line(org.organisation_code, element, oc.condition, oc.condition_value)
+        if line:
+            lines.add(line)
+
+    conditionstext = "\n".join(sorted(lines))
 
     strIO = StringIO()
     strIO.write(str(conditionstext))

--- a/iatidataquality/routes.py
+++ b/iatidataquality/routes.py
@@ -154,6 +154,12 @@ def organisation_feedback(organisation_code=None):
     return organisations_feedback.organisation_feedback(organisation_code)
 
 
+@app.route("/organisations/<organisation_code>/feedback/<int:feedback_id>/delete/", methods=['POST'])
+@usermanagement.perms_required('organisation_feedback', 'create')
+def delete_org_feedback(organisation_code, feedback_id):
+    return organisations_feedback.delete_org_feedback(organisation_code, feedback_id)
+
+
 @app.route("/registry/refresh/")
 @usermanagement.perms_required()
 def registry_refresh():

--- a/iatidataquality/static/js/organisationFeedback.js
+++ b/iatidataquality/static/js/organisationFeedback.js
@@ -5,6 +5,8 @@ $(document).on("click", ".deletefeedback", function(e){
 });
 var countfeedback = 0;
 $("#addfeedbackbtn").click(function(){
+    $("#no-conditions-row").remove();
+    $("#submitstructure").show();
     countfeedback ++;
     var uses = $("#uses").val();
     var element = $("#element option:selected").val();

--- a/iatidataquality/templates/import_organisation_conditions_step2.html
+++ b/iatidataquality/templates/import_organisation_conditions_step2.html
@@ -19,6 +19,7 @@
         <th>Import?</th>
 		<th>Organisation</th>
 		<th>Test</th>
+		<th>Test description</th>
 		<th>Operation</th>
 		<th>Condition</th>
 		<th>Condition value</th>
@@ -44,6 +45,8 @@
 					   value="{{test.id}}"/>
 			  <a href="{{url_for('get_tests', id=test.id)}}">{{test.name}}</a>
 			</td>
+
+			<td>{{test.description}}</td>
 
             <td><input type="hidden"
 					   name="pc[{{num}}{{loop.index}}][operation]"

--- a/iatidataquality/templates/organisation_feedback.html
+++ b/iatidataquality/templates/organisation_feedback.html
@@ -29,12 +29,17 @@
     (<code>hierarchy 2</code>).</p>
 
 
-    <p>
-	  <a class="btn btn-success" href="#addFeedback"
-		 role="button" data-bs-toggle="modal" data-bs-target="#addFeedback">
-		<i class="bi bi-plus-lg"></i>
-		<strong>Add conditions</strong></a>
-	</p>
+    {% if applied_conditions %}
+    <h4>Applied conditions</h4>
+    <p class="text-muted">These conditions have already been formally applied to this organisation's scoring.</p>
+    <ul class="list-group mb-3">
+      {% for line in applied_conditions %}
+      <li class="list-group-item font-monospace">{{line}}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
+    <hr>
 
     {% if existing_feedback %}
     <h4>Submitted conditions</h4>
@@ -59,17 +64,28 @@
     </table>
     {% endif %}
 
-    <h4>Add new conditions</h4>
+    <div class="d-flex align-items-center gap-3 mb-2">
+      <h4 class="mb-0">Add new conditions</h4>
+      <a class="btn btn-success btn-sm" href="#addFeedback"
+         role="button" data-bs-toggle="modal" data-bs-target="#addFeedback">
+        <i class="bi bi-plus-lg"></i> Add conditions
+      </a>
+    </div>
     <form name="organisationfeedback" method="post" action="">
     <table class="table" id="conditions">
     <thead>
     <tr><th>Conditions</th><th></th></tr>
     </thead>
     <tbody>
+      <tr id="no-conditions-row">
+        <td colspan="2" class="text-muted">You have not yet added any conditions.
+          <a href="#addFeedback" data-bs-toggle="modal" data-bs-target="#addFeedback">Add a new condition</a>.</td>
+      </tr>
     </tbody>
     </table>
-    <input type="submit" value="Submit structure"
-		   class="btn btn-outline-secondary btn-sm" name="submitstructure"/>
+    <input type="submit" value="Submit conditions"
+		   class="btn btn-outline-secondary btn-sm" name="submitstructure"
+		   id="submitstructure" style="display:none"/>
     </form>
 
     <div id="addFeedback" class="modal fade"

--- a/iatidataquality/templates/organisation_feedback.html
+++ b/iatidataquality/templates/organisation_feedback.html
@@ -36,10 +36,34 @@
 		<strong>Add conditions</strong></a>
 	</p>
 
+    {% if existing_feedback %}
+    <h4>Submitted conditions</h4>
+    <table class="table" id="saved-conditions">
+    <thead>
+    <tr><th>Condition</th><th></th></tr>
+    </thead>
+    <tbody>
+    {% for fb in existing_feedback %}
+    <tr>
+      <td>{{organisation.organisation_code}} {{fb.uses}} {{fb.element}} at {{fb.where}}</td>
+      <td>
+        <form method="post" action="{{url_for('delete_org_feedback', organisation_code=organisation.organisation_code, feedback_id=fb.id)}}" style="display:inline">
+          <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this condition?')">
+            <i class="bi bi-trash"></i>
+          </button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+    </table>
+    {% endif %}
+
+    <h4>Add new conditions</h4>
     <form name="organisationfeedback" method="post" action="">
     <table class="table" id="conditions">
     <thead>
-    <th>Conditions</th><th></th>
+    <tr><th>Conditions</th><th></th></tr>
     </thead>
     <tbody>
     </tbody>

--- a/iatidq/dqorganisations.py
+++ b/iatidq/dqorganisations.py
@@ -316,6 +316,7 @@ def deleteOrganisationPackage(organisation_code, package_name,
 
 def addFeedback(data):
     checkF = models.OrganisationConditionFeedback.query.filter_by(
+        organisation_id=data["organisation_id"],
         uses=data["uses"], element=data["element"], where=data["where"]
         ).first()
 
@@ -331,6 +332,15 @@ def addFeedback(data):
         db.session.add(feedback)
 
     return feedback
+
+
+def deleteFeedback(feedback_id):
+    feedback = models.OrganisationConditionFeedback.query.filter_by(id=feedback_id).first()
+    if feedback is None:
+        return False
+    with db.session.begin():
+        db.session.delete(feedback)
+    return True
 
 
 def make_publisher_summary(organisation, aggregation_type):

--- a/iatidq/dqparseconditions.py
+++ b/iatidq/dqparseconditions.py
@@ -46,7 +46,7 @@ def parsePC(organisation_structures):
         # after the 'then'
         print((groups[1]))
         like = re.compile(r'\sThen .*?{}'.format(groups[1]))
-        tests = [test for test in tests if like.search(test[1]) is not None]
+        tests = [test for test in tests if test[1] and like.search(test[1]) is not None]
         return organisation, tests
 
     @add_partial('(\S*) does not use (\S*) at activity level')


### PR DESCRIPTION
* Organisation conditions feedback could not previously be submitted; this is now fixed and can be viewed both by the donor submitting this information and by an admin
* Organisation conditions can now also be exported correctly, so that this can be set up again easily in a new Tracker
* Donors should also be able to view the conditions which have been applied to their data on their data structure page